### PR TITLE
Set GTK_CSD

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -85,6 +85,12 @@ public class Ideogram : Gtk.Application {
     }
 
     private static int main (string[] args) {
+        /*
+        * Workaround for https://github.com/cassidyjames/ideogram/issues/26
+        * Without GTK_CSD set, the fake window won't be styled correctly.
+        */
+        GLib.Environment.set_variable("GTK_CSD", "1", true);
+
         Gtk.init (ref args);
 
         var app = new Ideogram ();


### PR DESCRIPTION
Fixes #26

Tested on NixOS in Pantheon that didn't have `GTK_CSD` set.