### PR TITLE
Adds Timeouts to avoid the app closing before the paste.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -110,7 +110,7 @@ public class MainWindow : Gtk.Window {
         hide ();
 
         // Wait 500ms to ensure paste was successful
-        Timeout.add(500, () => {
+        Timeout.add (500, () => {
             close ();
 
             return false;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -74,19 +74,29 @@ public class MainWindow : Gtk.Window {
         entry.grab_focus ();
 
         entry.changed.connect (() => {
-            Gtk.Clipboard.get_default (this.get_display ()).set_text (entry.text, -1);
+            var clipboard = Gtk.Clipboard.get_for_display (entry.get_display (), Gdk.SELECTION_CLIPBOARD);
+            clipboard.set_text (entry.text, -1);
             hide ();
             paste ();
-            close ();
+            Timeout.add(500, () => {
+                close ();
+                return false;
+            });
         });
 
         if (is_terminal == false) {
             entry.focus_in_event.connect (() => {
-                close ();
+                Timeout.add(500, () => {
+                    close ();
+                    return false;
+                });
             });
 
             focus_out_event.connect ((event) => {
-                close ();
+                Timeout.add(500, () => {
+                    close ();
+                    return false;
+                });
                 return Gdk.EVENT_STOP;
             });
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright © 2018–2019 Cassidy James Blaede (https://cassidyjames.com)
+* Copyright © 2018–2021 Cassidy James Blaede (https://cassidyjames.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -76,27 +76,18 @@ public class MainWindow : Gtk.Window {
         entry.changed.connect (() => {
             var clipboard = Gtk.Clipboard.get_for_display (entry.get_display (), Gdk.SELECTION_CLIPBOARD);
             clipboard.set_text (entry.text, -1);
-            hide ();
             paste ();
-            Timeout.add(500, () => {
-                close ();
-                return false;
-            });
+            queue_close ();
         });
 
         if (is_terminal == false) {
             entry.focus_in_event.connect (() => {
-                Timeout.add(500, () => {
-                    close ();
-                    return false;
-                });
+                queue_close ();
             });
 
             focus_out_event.connect ((event) => {
-                Timeout.add(500, () => {
-                    close ();
-                    return false;
-                });
+                queue_close ();
+
                 return Gdk.EVENT_STOP;
             });
         }
@@ -113,6 +104,17 @@ public class MainWindow : Gtk.Window {
     private void paste () {
         perform_key_event ("<Control>v", true, 100);
         perform_key_event ("<Control>v", false, 0);
+    }
+
+    private void queue_close () {
+        hide ();
+
+        // Wait 500ms to ensure paste was successful
+        Timeout.add(500, () => {
+            close ();
+
+            return false;
+        });
     }
 
     private static void perform_key_event (string accelerator, bool press, ulong delay) {


### PR DESCRIPTION
Fixes #56

Basically the app closes before the paste keystroke actually occurs, which then clears the clipboard (this particular behavior appears to be what changed between Odin and Hera). I added a 500 millisecond timeout before the actual close happens, both when the entry change signal occurs as well as the focus in or out of the main window. The following line of code is what actually does it.

``` vala
Timeout.add(500, () => {
    close ();
    return false;
});
```

This does not feel like an ideal solution, ideally we would set it up so that the close function somehow waits for the keystroke to happen, or we could first store the clipboard data somewhere where the app could be closed without losing the clipboard data. I attempted to make each solution work but was unable to make it work. It would always either paste nothing or whatever was on my clipboard before the app was launched. More experimentation might yield a better solution, but for now I'm submitting this in the interest of getting something working.